### PR TITLE
Update InfluxDB Client to V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ kubectl expose service monitoring-influxdb --namespace=kube-system --type=Node
 # then open first URL, connect to DB using port from second URL and then create a new database
 $ minikube service influxdb --url --namespace kube-system
 # deploy prometheus node exporter from https://github.com/coreos/kube-prometheus/tree/master/manifests/exporters
-$ kubectl create -f node-exporter-svc.yaml -f node-exporter-ds.yaml
+$ kubectl create -f kube/node-exporter-svc.yaml -f kube/node-exporter-ds.yaml
 # test that it works
 $ curl $(minikube ip):9100/metrics
 # compile program

--- a/kube/node-exporter-ds.yaml
+++ b/kube/node-exporter-ds.yaml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+spec:
+  template:
+    metadata:
+      labels:
+        app: node-exporter
+      name: node-exporter
+    spec:
+      hostNetwork: true
+      hostPID: true
+      containers:
+      - image:  quay.io/prometheus/node-exporter:v0.13.0
+        args:
+        - "-collector.procfs=/host/proc"
+        - "-collector.sysfs=/host/sys"
+        name: node-exporter
+        ports:
+        - containerPort: 9100
+          hostPort: 9100
+          name: scrape
+        resources:
+          requests:
+            memory: 30Mi
+            cpu: 100m
+          limits:
+            memory: 50Mi
+            cpu: 200m
+        volumeMounts:
+        - name: proc
+          readOnly:  true
+          mountPath: /host/proc
+        - name: sys
+          readOnly: true
+          mountPath: /host/sys
+      volumes:
+      - name: proc
+        hostPath:
+          path: /proc
+      - name: sys
+        hostPath:
+          path: /sys

--- a/kube/node-exporter-svc.yaml
+++ b/kube/node-exporter-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: node-exporter
+    k8s-app: node-exporter
+  name: node-exporter
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: http-metrics
+    port: 9100
+    protocol: TCP
+  selector:
+    app: node-exporter

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/gravitational/mm/pkg/kubernetes"
 	"github.com/gravitational/mm/pkg/prometheus"
 	"github.com/gravitational/mm/pkg/util"
-	influx "github.com/influxdata/influxdb/client"
+	influx "github.com/influxdata/influxdb/client/v2"
 	watch "k8s.io/client-go/1.4/pkg/watch"
 )
 
@@ -102,7 +102,7 @@ func run(cfg constants.CommandLineFlags) error {
 		return trace.Wrap(err)
 	}
 
-	influxClient, err := influxdb.NewClient(influx.Config{URL: *u}, cfg.InfluxDBDatabaseName, "")
+	influxClient, err := influxdb.NewClient(influx.HTTPConfig{Addr: u.String()}, cfg.InfluxDBDatabaseName, "")
 	if err != nil {
 		return trace.Wrap(err, "can't create InfluxDB client")
 	}
@@ -141,7 +141,7 @@ func run(cfg constants.CommandLineFlags) error {
 			return trace.Wrap(err, "error reading metrics for %s", metricsURL)
 		}
 
-		_, err = influxClient.Send(metrics)
+		err = influxClient.Send(metrics)
 		if err != nil {
 			return trace.Wrap(err, "error sending metrics")
 		}


### PR DESCRIPTION
The client currently in use is the V1 client. The go import should be `github.com/influxdata/influxdb/client/v2` instead of `github.com/influxdata/influxdb/client`. The client changes were breaking so it required some code changes to manage this transition.

I've also added the `node-exporter-*.yaml` files to a `kube/` directory to make running the demo easier.